### PR TITLE
Add support for internal pull-up resistor

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -145,6 +145,9 @@ sample code bearing this copyright.
 OneWire::OneWire(uint8_t pin)
 {
 	pinMode(pin, INPUT);
+#if ONEWIRE_PULLUP
+	digitalWrite(pin, 1);
+#endif
 	bitmask = PIN_TO_BITMASK(pin);
 	baseReg = PIN_TO_BASEREG(pin);
 #if ONEWIRE_SEARCH
@@ -168,6 +171,9 @@ uint8_t OneWire::reset(void)
 
 	noInterrupts();
 	DIRECT_MODE_INPUT(reg, mask);
+#if ONEWIRE_PULLUP
+	DIRECT_WRITE_HIGH(reg, mask);
+#endif
 	interrupts();
 	// wait until the wire is high... just in case
 	do {
@@ -182,6 +188,9 @@ uint8_t OneWire::reset(void)
 	delayMicroseconds(480);
 	noInterrupts();
 	DIRECT_MODE_INPUT(reg, mask);	// allow it to float
+#if ONEWIRE_PULLUP
+	DIRECT_WRITE_HIGH(reg, mask);
+#endif
 	delayMicroseconds(70);
 	r = !DIRECT_READ(reg, mask);
 	interrupts();
@@ -232,6 +241,9 @@ uint8_t OneWire::read_bit(void)
 	DIRECT_WRITE_LOW(reg, mask);
 	delayMicroseconds(3);
 	DIRECT_MODE_INPUT(reg, mask);	// let pin float, pull up will raise
+#if ONEWIRE_PULLUP
+	DIRECT_WRITE_HIGH(reg, mask);
+#endif
 	delayMicroseconds(10);
 	r = DIRECT_READ(reg, mask);
 	interrupts();

--- a/OneWire.h
+++ b/OneWire.h
@@ -14,6 +14,13 @@
 #include "pins_arduino.h"  // for digitalPinToBitMask, etc
 #endif
 
+// You can enable the internal pullup resistor by defining this to 1
+// Then, no external resistor is needed for search; however this is
+// only likely to work for low power devices such as DS1990.
+#ifndef ONEWIRE_PULLUP
+#define ONEWIRE_PULLUP 1
+#endif
+
 // You can exclude certain features from OneWire.  In theory, this
 // might save some space.  In practice, the compiler automatically
 // removes unused code (technically, the linker, using -fdata-sections


### PR DESCRIPTION
On platforms such as Arduino, a new #define can now be set in OneWire.h
to enable the internal pull-up resistor. This means that no external
resistor is needed to search for 1-wire devices. Do not expect this to
work for temperature sensors and other such devices, that have higher
power requirements than simple serial number devices.